### PR TITLE
Blocked services: add new domain for youtube

### DIFF
--- a/home/blocked_services.go
+++ b/home/blocked_services.go
@@ -23,7 +23,7 @@ var serviceRulesArray = []svc{
 	{"whatsapp", []string{"||whatsapp.net^"}},
 	{"facebook", []string{"||facebook.com^"}},
 	{"twitter", []string{"||twitter.com^", "||t.co^", "||twimg.com^"}},
-	{"youtube", []string{"||youtube.com^", "||ytimg.com^"}},
+	{"youtube", []string{"||youtube.com^", "||ytimg.com^", "||googlevideo.com^"}},
 	{"messenger", []string{"||fb.com^", "||facebook.com^"}},
 	{"twitch", []string{"||twitch.tv^", "||ttvnw.net^"}},
 	{"netflix", []string{"||nflxext.com^", "||netflix.com^"}},


### PR DESCRIPTION
Necessary to add googlevideo.com to avoid users keep/resume download youtube videos